### PR TITLE
feat(tslint-config): Use array literal syntax

### DIFF
--- a/src/configs/tslint-microsoft-contrib-override.ts
+++ b/src/configs/tslint-microsoft-contrib-override.ts
@@ -8,7 +8,6 @@ export default {
         "no-increment-decrement": false,
         "no-relative-imports": false,
         "no-suspicious-comment": false,
-        "prefer-array-literal": [true, { 'allow-type-parameters': true }],
         "prefer-type-cast": false
     }
 };

--- a/src/configs/tslint-override.ts
+++ b/src/configs/tslint-override.ts
@@ -6,7 +6,7 @@ export default {
         // Style
         "array-type": [
             true,
-            "generic"
+            "array"
         ],
         "arrow-parens": [
             true,


### PR DESCRIPTION
Use array literal syntax when declaring or instantiating array types