### PR TITLE
feat(tslint-config): rule for setting blank lines count for blocks

### DIFF
--- a/src/configs/tslint-override.ts
+++ b/src/configs/tslint-override.ts
@@ -35,6 +35,7 @@ export default {
             }
         ],
         "radix": false,
+        "no-consecutive-blank-lines": false,
         "no-console": [true, "log", "debug", "error"],
         "no-duplicate-switch-case": true,
         "no-for-in-array": true,

--- a/src/rules/blankLinesRule.ts
+++ b/src/rules/blankLinesRule.ts
@@ -1,0 +1,184 @@
+import * as Lint from 'tslint';
+import * as utils from 'tsutils';
+import * as ts from 'typescript';
+
+
+const AFTER_IMPORTS = 'after-imports';
+const ABOVE_CONDITIONAL = 'above-conditional';
+const ABOVE_METHOD = 'above-method';
+
+const DEFAULT_COUNT_OF_BLANK_LINES = 1;
+
+interface Options {
+    afterImports: number;
+    aboveConditional: number;
+    aboveMethod: number;
+}
+
+interface ConfigOptions {
+    'after-imports': number;
+    'above-conditional': number;
+    'above-method': number;
+}
+
+const parseConfigOptions = (configOptions: ConfigOptions): Options => {
+    const options: Options = {
+        afterImports: DEFAULT_COUNT_OF_BLANK_LINES,
+        aboveConditional: DEFAULT_COUNT_OF_BLANK_LINES,
+        aboveMethod: DEFAULT_COUNT_OF_BLANK_LINES
+    };
+
+    if (configOptions) {
+        options.afterImports = configOptions[AFTER_IMPORTS] || DEFAULT_COUNT_OF_BLANK_LINES;
+        options.aboveConditional = configOptions[ABOVE_CONDITIONAL] || DEFAULT_COUNT_OF_BLANK_LINES;
+        options.aboveMethod = configOptions[ABOVE_METHOD] || DEFAULT_COUNT_OF_BLANK_LINES;
+    }
+
+    return options;
+};
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: 'blank-lines',
+        description: 'Disallows one or more blank lines in a row after or above statements.',
+        type: 'style',
+        typescriptOnly: false,
+        options: {
+            properties: {
+                [AFTER_IMPORTS]: {
+                    type: 'number',
+                    minimum: '1'
+                },
+                [ABOVE_CONDITIONAL]: {
+                    type: 'number',
+                    minimum: '1'
+                },
+                [ABOVE_METHOD]: {
+                    type: 'number',
+                    minimum: '1'
+                }
+            },
+            type: 'object'
+        },
+        optionsDescription: Lint.Utils.dedent`
+            Three options must be provided on an object:
+            * \`${AFTER_IMPORTS}\` sets count of blank lines after imports.
+            * \`${ABOVE_CONDITIONAL}\` sets count of blank lines above conditional.
+            * \`${ABOVE_METHOD}\` sets count of blank lines above method.`,
+        optionExamples: [
+            true,
+            [
+                true,
+                {
+                    [AFTER_IMPORTS]: 2,
+                    [ABOVE_CONDITIONAL]: 1,
+                    [ABOVE_METHOD]: 1
+                }
+            ]
+        ],
+        rationale: 'Helps maintain a readable style in your codebase.'
+    };
+
+    public static FAILURE_STRING_FACTORY(failureType: string, allowed: number): string {
+        return `You need to use ${allowed} consecutive blank lines ${failureType.replace('-', ' ')}`;
+    }
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const options = parseConfigOptions((this.ruleArguments as [ConfigOptions])[0]);
+
+        return this.applyWithWalker(new BlankLinesWalker(sourceFile, this.ruleName, options));
+    }
+}
+
+class BlankLinesWalker extends Lint.AbstractWalker<Options> {
+    public walk(sourceFile: ts.SourceFile): void {
+        ts.forEachChild(sourceFile, (child) => this.visitNode(child));
+    }
+
+    private visitNode(node: ts.Node): void {
+        switch (node.kind) {
+            case ts.SyntaxKind.ImportDeclaration:
+                return this.visitImportDeclaration(node as ts.ImportDeclaration);
+            case ts.SyntaxKind.IfStatement:
+            case ts.SyntaxKind.DoStatement:
+            case ts.SyntaxKind.WhileStatement:
+            case ts.SyntaxKind.ForStatement:
+            case ts.SyntaxKind.ForInStatement:
+            case ts.SyntaxKind.ForOfStatement:
+                return this.visitConditionalExpression(node as ts.Statement);
+            case ts.SyntaxKind.MethodDeclaration:
+                return this.visitMethodDeclaration(node as ts.Statement);
+            default:
+                return ts.forEachChild(node, (child) => this.visitNode(child));
+        }
+    }
+
+    private visitImportDeclaration(node: ts.ImportDeclaration): void {
+        const next = utils.getNextStatement(node);
+
+        if (next === undefined || utils.isImportDeclaration(next)) {
+            // there are no any statements afterward import or it isn't the last import
+            // so we can just ignore blank lines if there are any
+            return;
+        }
+
+        const blankLinesAfterImport: number = this.getBlankLines(next);
+
+        if (blankLinesAfterImport !== this.options.afterImports) {
+            this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(AFTER_IMPORTS, this.options.afterImports));
+        }
+    }
+
+    private visitMethodDeclaration(node: ts.Statement): void {
+        const blankLinesAboveMethod: number = this.getBlankLines(node);
+
+        if (blankLinesAboveMethod !== this.options.aboveMethod) {
+            this.addFailureAt(
+                node.getStart(),
+                1,
+                Rule.FAILURE_STRING_FACTORY(ABOVE_METHOD, this.options.aboveMethod)
+            );
+        }
+    }
+
+    private visitConditionalExpression(node: ts.Statement): void {
+        const prev = utils.getPreviousStatement(node);
+
+        if (prev === undefined) {
+            return;
+        }
+
+        const blankLinesAboveConditional: number = this.getBlankLines(node);
+
+        if (blankLinesAboveConditional !== this.options.aboveConditional) {
+            this.addFailureAt(
+                node.getStart(),
+                1,
+                Rule.FAILURE_STRING_FACTORY(ABOVE_CONDITIONAL, this.options.aboveConditional)
+            );
+        }
+    }
+
+    private getBlankLines(node: ts.Node): number {
+        const nodeText = node.getFullText();
+        let isLineBreakAtStart = true;
+
+        return nodeText
+            .split('')
+            .reduce<number>(
+                (memo, char) => {
+                    const code = char.charCodeAt(0) || 0;
+
+                    if (isLineBreakAtStart && ts.isLineBreak(code)) {
+                        return memo + 1;
+                    } else if (!ts.isWhiteSpaceLike(code)) {
+                        isLineBreakAtStart = false;
+                    }
+
+                    return memo;
+                },
+                // first line break it isn't a blank line
+                -1
+            );
+    }
+}

--- a/test/rules/blank-lines/above-conditional/test.ts.lint
+++ b/test/rules/blank-lines/above-conditional/test.ts.lint
@@ -1,0 +1,25 @@
+const theAnswer = 42;
+let test;
+
+if (theAnswer === 42) {
+~ [wrong-blank-lines-count-above-conditional]
+    test = true;
+}
+
+
+const array = [1, 2, 3];
+let test;
+for (const item in array) {
+~ [wrong-blank-lines-count-above-conditional]
+    test = true;
+}
+
+
+let test;
+
+
+while (true) {
+    test = true;
+}
+
+[wrong-blank-lines-count-above-conditional]: You need to use 2 consecutive blank lines above conditional

--- a/test/rules/blank-lines/above-conditional/tslint.json
+++ b/test/rules/blank-lines/above-conditional/tslint.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "blank-lines": [true, {
+            "above-conditional": 2
+        }]
+    }
+}

--- a/test/rules/blank-lines/above-method/test.ts.lint
+++ b/test/rules/blank-lines/above-method/test.ts.lint
@@ -1,0 +1,22 @@
+class TestClass {
+    constructor() {
+        console.log('123');
+    }
+
+    testMethod() {
+    ~ [wrong-blank-lines-count-above-method]
+        // do smth
+    }
+    private testMethod2() {
+    ~ [wrong-blank-lines-count-above-method]
+        // do smth2
+    }
+
+
+    protected testMethod3() {
+        // do smth3
+    }
+}
+
+
+[wrong-blank-lines-count-above-method]: You need to use 2 consecutive blank lines above method

--- a/test/rules/blank-lines/above-method/tslint.json
+++ b/test/rules/blank-lines/above-method/tslint.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "blank-lines": [true, {
+            "above-method": 2
+        }]
+    }
+}

--- a/test/rules/blank-lines/after-imports/test.ts.lint
+++ b/test/rules/blank-lines/after-imports/test.ts.lint
@@ -1,0 +1,36 @@
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~ [wrong-blank-lines-count-after-imports]
+const theAnswer = 42;
+
+
+
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~ [wrong-blank-lines-count-after-imports]
+
+const theAnswer = 42;
+
+
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~ [wrong-blank-lines-count-after-imports]
+
+
+
+const theAnswer = 42;
+
+
+
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+
+
+const theAnswer = 42;
+
+
+[wrong-blank-lines-count-after-imports]: You need to use 2 consecutive blank lines after imports

--- a/test/rules/blank-lines/after-imports/tslint.json
+++ b/test/rules/blank-lines/after-imports/tslint.json
@@ -1,5 +1,5 @@
-export default {
-    rules: {
+{
+    "rules": {
         "blank-lines": [true, {
             "after-imports": 2
         }]

--- a/test/rules/blank-lines/default/test.ts.lint
+++ b/test/rules/blank-lines/default/test.ts.lint
@@ -1,0 +1,61 @@
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~ [wrong-blank-lines-count-after-imports]
+const theAnswer = 42;
+
+
+
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+
+const theAnswer = 42;
+
+
+
+import {A, B} from 'foo';
+
+import {C, D} from 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~ [wrong-blank-lines-count-after-imports]
+
+
+const theAnswer = 42;
+let test;
+
+if (theAnswer === 42) {
+    test = true;
+}
+
+
+const theAnswer = 42;
+let test;
+if (theAnswer === 42) {
+~ [wrong-blank-lines-count-above-conditional]
+    test = true;
+}
+
+class TestClass {
+    constructor() {
+        console.log('123');
+    }
+
+    testMethod() {
+        // do smth
+    }
+    testMethod2() {
+    ~ [wrong-blank-lines-count-above-method]
+        // do smth2
+    }
+
+
+    testMethod3() {
+    ~ [wrong-blank-lines-count-above-method]
+        // do smth3
+    }
+}
+
+[wrong-blank-lines-count]: You need to use 1 consecutive blank lines %s
+[wrong-blank-lines-count-after-imports]: wrong-blank-lines-count % ('after imports')
+[wrong-blank-lines-count-above-conditional]: wrong-blank-lines-count % ('above conditional')
+[wrong-blank-lines-count-above-method]: wrong-blank-lines-count % ('above method')

--- a/test/rules/blank-lines/default/tslint.json
+++ b/test/rules/blank-lines/default/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "blank-lines": true
+    }
+}


### PR DESCRIPTION
Новое правило, которое позволяет гибко настраивать кол-во пустых строк до или после определенного блока, например после блока импортов или перед методами