### PR TITLE
fix(tslint-config): 'blank-lines' false positives for methods

### DIFF
--- a/src/rules/blankLinesRule.ts
+++ b/src/rules/blankLinesRule.ts
@@ -112,7 +112,7 @@ class BlankLinesWalker extends Lint.AbstractWalker<Options> {
             case ts.SyntaxKind.ForOfStatement:
                 return this.visitConditionalExpression(node as ts.Statement);
             case ts.SyntaxKind.MethodDeclaration:
-                return this.visitMethodDeclaration(node as ts.Statement);
+                return this.visitMethodDeclaration(node as ts.MethodDeclaration);
             default:
                 return ts.forEachChild(node, (child) => this.visitNode(child));
         }
@@ -134,7 +134,19 @@ class BlankLinesWalker extends Lint.AbstractWalker<Options> {
         }
     }
 
-    private visitMethodDeclaration(node: ts.Statement): void {
+    private visitMethodDeclaration(node: ts.MethodDeclaration): void {
+        const parent = node.parent;
+
+        if (!parent || parent.kind !== ts.SyntaxKind.ClassDeclaration) {
+            return;
+        }
+
+        const firstClassMember = (node.parent as ts.ClassDeclaration).members[0];
+
+        if (firstClassMember === node) {
+            return;
+        }
+
         const blankLinesAboveMethod: number = this.getBlankLines(node);
 
         if (blankLinesAboveMethod !== this.options.aboveMethod) {

--- a/test/rules/blank-lines/above-method/test.ts.lint
+++ b/test/rules/blank-lines/above-method/test.ts.lint
@@ -19,4 +19,30 @@ class TestClass {
 }
 
 
+class TestClass {
+    testMethod() {
+        // do smth
+    }
+    private testMethod2() {
+    ~ [wrong-blank-lines-count-above-method]
+        // do smth2
+    }
+
+
+    protected testMethod3() {
+        // do smth3
+    }
+}
+
+
+return {
+    equals(currentState, previousState) {
+        return _.isEqual(currentState, previousState);
+    },
+    test() {
+        return 123;
+    }
+});
+
+
 [wrong-blank-lines-count-above-method]: You need to use 2 consecutive blank lines above method


### PR DESCRIPTION
Правило ошибочно срабатывало для функций в объекте, хотя 'above-method' задумывался только для методов класса.

Также добавила проверку на то, что метод является первым в объявлении и поэтому для него не нужно совпадение кол-ва пустых строк сверху и заданного в конфиге значения.