### PR TITLE
feat(tslint-config): extend whitespace rule

### DIFF
--- a/src/configs/tslint-override.ts
+++ b/src/configs/tslint-override.ts
@@ -15,6 +15,19 @@ export default {
         "no-unnecessary-callback-wrapper": true,
         "prefer-template": true,
         "variable-name": [true, "check-format", "allow-leading-underscore", "allow-pascal-case"],
+        "whitespace": [
+                true,
+                "check-branch",
+                "check-decl",
+                "check-operator",
+                "check-module",
+                "check-separator",
+                "check-rest-spread",
+                "check-type",
+                "check-typecast",
+                "check-type-operator",
+                "check-preblock"
+        ],
 
         // Functionality
         "await-promise": [


### PR DESCRIPTION
Изначально добавлял контроль над пробелами в `import` (внутри `{}`).