### PR TITLE
Set "no-stateless-class" rule to "false"

### DIFF
--- a/src/configs/tslint-microsoft-contrib-override.ts
+++ b/src/configs/tslint-microsoft-contrib-override.ts
@@ -11,6 +11,7 @@ export default {
         "no-suspicious-comment": false,
         "prefer-type-cast": false,
         "no-var-self": false, // Deprecated. Use 'no-this-assignment' instead
-        "no-backbone-get-set-outside-model": false
+        "no-backbone-get-set-outside-model": false,
+        "no-stateless-class": false
     }
 };


### PR DESCRIPTION
Common scenario for Angualr 2+ apps with empty class:

```
@NgModule({
    declarations: [
        CommonPopupComponent
    ],
    imports: [
        BrowserModule
    ],
    providers: [],
    entryComponents: [
        CommonPopupComponent
    ]
})
export class CommonPopupModule { }
```