### PR TITLE
feat: defined rules with type check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@ptsecurity/tslint-config",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10,16 +10,16 @@
             "integrity": "sha1-O/htirL71QdMMRS3uj9LQbd189w=",
             "dev": true,
             "requires": {
-                "@commitlint/format": "7.0.0",
-                "@commitlint/lint": "7.0.0",
-                "@commitlint/load": "7.0.0",
-                "@commitlint/read": "7.0.0",
+                "@commitlint/format": "^7.0.0",
+                "@commitlint/lint": "^7.0.0",
+                "@commitlint/load": "^7.0.0",
+                "@commitlint/read": "^7.0.0",
                 "babel-polyfill": "6.26.0",
                 "chalk": "2.3.1",
                 "get-stdin": "5.0.1",
                 "lodash.merge": "4.6.1",
                 "lodash.pick": "4.4.0",
-                "meow": "5.0.0"
+                "meow": "^5.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -28,7 +28,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.2"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -37,9 +37,9 @@
                     "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -48,7 +48,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -87,8 +87,8 @@
             "integrity": "sha1-O+H98MPEH+uY4nW09gXFmMUJuSA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "chalk": "2.4.1"
+                "babel-runtime": "^6.23.0",
+                "chalk": "^2.0.1"
             }
         },
         "@commitlint/is-ignored": {
@@ -106,10 +106,10 @@
             "integrity": "sha1-rt6eFfVRuCKvfZ2lXfSIGtODkNk=",
             "dev": true,
             "requires": {
-                "@commitlint/is-ignored": "7.0.0",
-                "@commitlint/parse": "7.0.0",
-                "@commitlint/rules": "7.0.0",
-                "babel-runtime": "6.26.0",
+                "@commitlint/is-ignored": "^7.0.0",
+                "@commitlint/parse": "^7.0.0",
+                "@commitlint/rules": "^7.0.0",
+                "babel-runtime": "^6.23.0",
                 "lodash.topairs": "4.3.0"
             }
         },
@@ -119,10 +119,10 @@
             "integrity": "sha1-2ST0xcBtiEWxalC1Y4Kaf/+iMKg=",
             "dev": true,
             "requires": {
-                "@commitlint/execute-rule": "7.0.0",
-                "@commitlint/resolve-extends": "7.0.0",
-                "babel-runtime": "6.26.0",
-                "cosmiconfig": "4.0.0",
+                "@commitlint/execute-rule": "^7.0.0",
+                "@commitlint/resolve-extends": "^7.0.0",
+                "babel-runtime": "^6.23.0",
+                "cosmiconfig": "^4.0.0",
                 "lodash.merge": "4.6.1",
                 "lodash.mergewith": "4.6.1",
                 "lodash.pick": "4.4.0",
@@ -142,8 +142,8 @@
             "integrity": "sha1-7QJMxNjwh0QhqN1tFmdCM7aFktQ=",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "1.6.6",
-                "conventional-commits-parser": "2.1.7"
+                "conventional-changelog-angular": "^1.3.3",
+                "conventional-commits-parser": "^2.1.0"
             }
         },
         "@commitlint/read": {
@@ -152,10 +152,10 @@
             "integrity": "sha1-yb8iLjfgTDPB4ltJhlf+9oN34sg=",
             "dev": true,
             "requires": {
-                "@commitlint/top-level": "7.0.0",
-                "@marionebl/sander": "0.6.1",
-                "babel-runtime": "6.26.0",
-                "git-raw-commits": "1.3.6"
+                "@commitlint/top-level": "^7.0.0",
+                "@marionebl/sander": "^0.6.0",
+                "babel-runtime": "^6.23.0",
+                "git-raw-commits": "^1.3.0"
             }
         },
         "@commitlint/resolve-extends": {
@@ -167,9 +167,9 @@
                 "babel-runtime": "6.26.0",
                 "lodash.merge": "4.6.1",
                 "lodash.omit": "4.5.0",
-                "require-uncached": "1.0.3",
-                "resolve-from": "4.0.0",
-                "resolve-global": "0.1.0"
+                "require-uncached": "^1.0.3",
+                "resolve-from": "^4.0.0",
+                "resolve-global": "^0.1.0"
             }
         },
         "@commitlint/rules": {
@@ -178,10 +178,10 @@
             "integrity": "sha1-mnEIkcNQwQ1vYt67gg/uT97x4CY=",
             "dev": true,
             "requires": {
-                "@commitlint/ensure": "7.0.0",
-                "@commitlint/message": "7.0.0",
-                "@commitlint/to-lines": "7.0.0",
-                "babel-runtime": "6.26.0"
+                "@commitlint/ensure": "^7.0.0",
+                "@commitlint/message": "^7.0.0",
+                "@commitlint/to-lines": "^7.0.0",
+                "babel-runtime": "^6.23.0"
             }
         },
         "@commitlint/to-lines": {
@@ -196,18 +196,18 @@
             "integrity": "sha1-/yhYCrjBQxKQ43sdUH4O83DDjZk=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "@marionebl/sander": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@marionebl/sander/-/sander-0.6.1.tgz",
             "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.3",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.2"
             }
         },
         "@ptsecurity/commitlint-config": {
@@ -228,7 +228,7 @@
             "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.9.5"
+                "@types/node": "*"
             }
         },
         "@types/glob": {
@@ -237,9 +237,9 @@
             "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
             "dev": true,
             "requires": {
-                "@types/events": "1.2.0",
-                "@types/minimatch": "3.0.3",
-                "@types/node": "8.9.5"
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
             }
         },
         "@types/minimatch": {
@@ -260,8 +260,8 @@
             "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.35",
-                "@types/node": "8.9.5"
+                "@types/glob": "*",
+                "@types/node": "*"
             }
         },
         "JSONStream": {
@@ -270,8 +270,8 @@
             "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
             "dev": true,
             "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
             }
         },
         "add-stream": {
@@ -286,9 +286,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -312,12 +312,12 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "array-filter": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-filter/-/array-filter-0.0.1.tgz",
             "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
             "dev": true
         },
@@ -335,13 +335,13 @@
         },
         "array-map": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-map/-/array-map-0.0.0.tgz",
             "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
             "dev": true
         },
         "array-reduce": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-reduce/-/array-reduce-0.0.0.tgz",
             "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
             "dev": true
         },
@@ -362,9 +362,9 @@
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -372,29 +372,29 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 }
             }
         },
         "babel-polyfill": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             },
             "dependencies": {
                 "regenerator-runtime": {
                     "version": "0.10.5",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                     "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
                     "dev": true
                 }
@@ -402,12 +402,12 @@
         },
         "babel-runtime": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "balanced-match": {
@@ -420,7 +420,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -432,21 +432,21 @@
         },
         "builtin-modules": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
         },
         "caller-path": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/caller-path/-/caller-path-0.1.0.tgz",
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/callsites/-/callsites-0.2.0.tgz",
             "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
             "dev": true
         },
@@ -462,9 +462,9 @@
             "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0",
-                "map-obj": "2.0.0",
-                "quick-lru": "1.1.0"
+                "camelcase": "^4.1.0",
+                "map-obj": "^2.0.0",
+                "quick-lru": "^1.0.0"
             }
         },
         "center-align": {
@@ -474,8 +474,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -483,9 +483,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -493,7 +493,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "1.9.2"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "supports-color": {
@@ -501,7 +501,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -518,7 +518,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-spinners": {
@@ -534,8 +534,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -578,8 +578,8 @@
             "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
             "dev": true,
             "requires": {
-                "array-ify": "1.0.0",
-                "dot-prop": "3.0.0"
+                "array-ify": "^1.0.0",
+                "dot-prop": "^3.0.0"
             }
         },
         "concat-map": {
@@ -593,17 +593,17 @@
             "integrity": "sha512-WeWcEcR7uBtRZ/uG6DRIlVqsm7UTnxrixaAPoPvfQP7FRPf1qIXL76nGKy4wXq+wO3zOpqYubWUqrYLIL3+xww==",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "1.6.6",
-                "conventional-changelog-atom": "2.0.0",
-                "conventional-changelog-codemirror": "2.0.0",
-                "conventional-changelog-core": "3.0.0",
-                "conventional-changelog-ember": "2.0.0",
-                "conventional-changelog-eslint": "3.0.0",
-                "conventional-changelog-express": "2.0.0",
-                "conventional-changelog-jquery": "0.1.0",
-                "conventional-changelog-jscs": "0.1.0",
-                "conventional-changelog-jshint": "2.0.0",
-                "conventional-changelog-preset-loader": "2.0.0"
+                "conventional-changelog-angular": "^1.6.6",
+                "conventional-changelog-atom": "^2.0.0",
+                "conventional-changelog-codemirror": "^2.0.0",
+                "conventional-changelog-core": "^3.0.0",
+                "conventional-changelog-ember": "^2.0.0",
+                "conventional-changelog-eslint": "^3.0.0",
+                "conventional-changelog-express": "^2.0.0",
+                "conventional-changelog-jquery": "^0.1.0",
+                "conventional-changelog-jscs": "^0.1.0",
+                "conventional-changelog-jshint": "^2.0.0",
+                "conventional-changelog-preset-loader": "^2.0.0"
             }
         },
         "conventional-changelog-angular": {
@@ -612,8 +612,8 @@
             "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "q": "1.5.1"
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-atom": {
@@ -622,7 +622,7 @@
             "integrity": "sha512-ygwkwyTQYAm4S0tsDt+1yg8tHhRrv7qu9SOWPhNQlVrInFLsfKc0FActCA3de2ChknxpVPY2B53yhKvCAtkBCg==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-cli": {
@@ -631,11 +631,11 @@
             "integrity": "sha512-gQzMbLyPNYymbzJncJNBapLZTXEtXrq6qmQOJH0w/jVX9fxIli4sLalQgzEPjD7M1noLJd1cIdQAP1R++TkGxg==",
             "dev": true,
             "requires": {
-                "add-stream": "1.0.0",
-                "conventional-changelog": "2.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "tempfile": "1.1.1"
+                "add-stream": "^1.0.0",
+                "conventional-changelog": "^2.0.1",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "tempfile": "^1.1.1"
             },
             "dependencies": {
                 "meow": {
@@ -644,15 +644,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -663,7 +663,7 @@
             "integrity": "sha512-pZt/YynJ5m8C9MGV5wkBuhM1eX+8a84fmNrdOylxg/lJV+lgtAiNhnpskNuixtf71iKVWSlEqMQ6z6CH7/Uo5A==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-core": {
@@ -672,19 +672,19 @@
             "integrity": "sha512-D2hApWWsdh4tkNgDjn1KtRapxUJ70Sd+V84btTVJJJ96S3cVRES8Ty3ih0TRkOZmDkw/uS0mxrHSskQ/P/Gvsg==",
             "dev": true,
             "requires": {
-                "conventional-changelog-writer": "4.0.0",
-                "conventional-commits-parser": "3.0.0",
-                "dateformat": "3.0.3",
-                "get-pkg-repo": "1.4.0",
-                "git-raw-commits": "2.0.0",
-                "git-remote-origin-url": "2.0.0",
-                "git-semver-tags": "2.0.0",
-                "lodash": "4.17.10",
-                "normalize-package-data": "2.4.0",
-                "q": "1.5.1",
-                "read-pkg": "1.1.0",
-                "read-pkg-up": "1.0.1",
-                "through2": "2.0.3"
+                "conventional-changelog-writer": "^4.0.0",
+                "conventional-commits-parser": "^3.0.0",
+                "dateformat": "^3.0.0",
+                "get-pkg-repo": "^1.0.0",
+                "git-raw-commits": "^2.0.0",
+                "git-remote-origin-url": "^2.0.0",
+                "git-semver-tags": "^2.0.0",
+                "lodash": "^4.2.1",
+                "normalize-package-data": "^2.3.5",
+                "q": "^1.5.1",
+                "read-pkg": "^1.1.0",
+                "read-pkg-up": "^1.0.1",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "conventional-commits-parser": {
@@ -693,13 +693,13 @@
                     "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
                     "dev": true,
                     "requires": {
-                        "JSONStream": "1.3.3",
-                        "is-text-path": "1.0.1",
-                        "lodash": "4.17.10",
-                        "meow": "4.0.1",
-                        "split2": "2.2.0",
-                        "through2": "2.0.3",
-                        "trim-off-newlines": "1.0.1"
+                        "JSONStream": "^1.0.4",
+                        "is-text-path": "^1.0.0",
+                        "lodash": "^4.2.1",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "trim-off-newlines": "^1.0.0"
                     }
                 },
                 "git-raw-commits": {
@@ -708,11 +708,11 @@
                     "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
                     "dev": true,
                     "requires": {
-                        "dargs": "4.1.0",
-                        "lodash.template": "4.4.0",
-                        "meow": "4.0.1",
-                        "split2": "2.2.0",
-                        "through2": "2.0.3"
+                        "dargs": "^4.0.1",
+                        "lodash.template": "^4.0.2",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "meow": {
@@ -721,15 +721,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     },
                     "dependencies": {
                         "read-pkg": {
@@ -738,9 +738,9 @@
                             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                             "dev": true,
                             "requires": {
-                                "load-json-file": "4.0.0",
-                                "normalize-package-data": "2.4.0",
-                                "path-type": "3.0.0"
+                                "load-json-file": "^4.0.0",
+                                "normalize-package-data": "^2.3.2",
+                                "path-type": "^3.0.0"
                             }
                         },
                         "read-pkg-up": {
@@ -749,8 +749,8 @@
                             "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                             "dev": true,
                             "requires": {
-                                "find-up": "2.1.0",
-                                "read-pkg": "3.0.0"
+                                "find-up": "^2.0.0",
+                                "read-pkg": "^3.0.0"
                             }
                         }
                     }
@@ -761,7 +761,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -770,7 +770,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -785,9 +785,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     },
                     "dependencies": {
                         "load-json-file": {
@@ -796,11 +796,11 @@
                             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "parse-json": "2.2.0",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1",
-                                "strip-bom": "2.0.0"
+                                "graceful-fs": "^4.1.2",
+                                "parse-json": "^2.2.0",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0",
+                                "strip-bom": "^2.0.0"
                             }
                         },
                         "path-type": {
@@ -809,9 +809,9 @@
                             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1"
+                                "graceful-fs": "^4.1.2",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -822,8 +822,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -832,8 +832,8 @@
                             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                             "dev": true,
                             "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -844,7 +844,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -855,7 +855,7 @@
             "integrity": "sha512-s9ZYf3VMdYe8ca8bw1X+he050HZNy9Pm3dBpYA+BunDGFE4Fy7whOvYhWah2U9+j9l6y/whfa0+eHANvZytE9A==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-eslint": {
@@ -864,7 +864,7 @@
             "integrity": "sha512-Acn20v+13c+o1OAWKvc9sCCl73Nj2vOMyn+G82euiMZwgYNE9CcBkTnw/GKdBi9KiZMK9uy+SCQ/QyAEE+8vZA==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-express": {
@@ -873,7 +873,7 @@
             "integrity": "sha512-2svPjeXCrjwwqnzu/f3qU5LWoLO0jmUIEbtbbSRXAAP9Ag+137b484eJsiRt9DPYXSVzog0Eoek3rvCzfHcphQ==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-jquery": {
@@ -882,7 +882,7 @@
             "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.4.1"
             }
         },
         "conventional-changelog-jscs": {
@@ -891,7 +891,7 @@
             "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.4.1"
             }
         },
         "conventional-changelog-jshint": {
@@ -900,8 +900,8 @@
             "integrity": "sha512-+4fCln755N0ZzRUEdcDWR5Due71Dsqkbov6K/UmVCnljZvhVh0/wpT4YROoSsAnhfZO8shyWDPFKm6EP20pLQg==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "q": "1.5.1"
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-preset-loader": {
@@ -916,16 +916,16 @@
             "integrity": "sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "conventional-commits-filter": "2.0.0",
-                "dateformat": "3.0.3",
-                "handlebars": "4.0.11",
-                "json-stringify-safe": "5.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "semver": "5.5.0",
-                "split": "1.0.1",
-                "through2": "2.0.3"
+                "compare-func": "^1.3.1",
+                "conventional-commits-filter": "^2.0.0",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.0.2",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "semver": "^5.5.0",
+                "split": "^1.0.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "meow": {
@@ -934,15 +934,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -953,8 +953,8 @@
             "integrity": "sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==",
             "dev": true,
             "requires": {
-                "is-subset": "0.1.1",
-                "modify-values": "1.0.1"
+                "is-subset": "^0.1.1",
+                "modify-values": "^1.0.0"
             }
         },
         "conventional-commits-parser": {
@@ -963,13 +963,13 @@
             "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
-                "is-text-path": "1.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "split2": "2.2.0",
-                "through2": "2.0.3",
-                "trim-off-newlines": "1.0.1"
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
             },
             "dependencies": {
                 "meow": {
@@ -978,15 +978,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -1009,10 +1009,10 @@
             "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
             "dev": true,
             "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.12.0",
-                "parse-json": "4.0.0",
-                "require-from-string": "2.0.2"
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.9.0",
+                "parse-json": "^4.0.0",
+                "require-from-string": "^2.0.1"
             }
         },
         "cross-spawn": {
@@ -1021,11 +1021,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "1.0.4",
-                "path-key": "2.0.1",
-                "semver": "5.5.0",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "currently-unhandled": {
@@ -1034,7 +1034,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "dargs": {
@@ -1043,7 +1043,7 @@
             "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "dateformat": {
@@ -1060,12 +1060,12 @@
         },
         "decamelize-keys": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
             "dev": true,
             "requires": {
-                "decamelize": "1.2.0",
-                "map-obj": "1.0.1"
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "map-obj": {
@@ -1082,17 +1082,17 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4"
+                "clone": "^1.0.2"
             }
         },
         "define-properties": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-properties/-/define-properties-1.1.2.tgz",
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.12"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "diff": {
@@ -1102,16 +1102,16 @@
         },
         "doctrine": {
             "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/doctrine/-/doctrine-0.7.2.tgz",
             "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
             "requires": {
-                "esutils": "1.1.6",
+                "esutils": "^1.1.6",
                 "isarray": "0.0.1"
             },
             "dependencies": {
                 "esutils": {
                     "version": "1.1.6",
-                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/esutils/-/esutils-1.1.6.tgz",
                     "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
                 }
             }
@@ -1122,12 +1122,12 @@
             "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
@@ -1137,7 +1137,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -1146,22 +1146,22 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.3",
-                "is-callable": "1.1.4",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
             }
         },
         "es-to-primitive": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
             "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.4",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "is-callable": "^1.1.1",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.1"
             }
         },
         "escape-string-regexp": {
@@ -1181,17 +1181,17 @@
         },
         "event-stream": {
             "version": "3.3.4",
-            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             },
             "dependencies": {
                 "split": {
@@ -1200,7 +1200,7 @@
                     "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
                     "dev": true,
                     "requires": {
-                        "through": "2.3.8"
+                        "through": "2"
                     }
                 }
             }
@@ -1211,18 +1211,18 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "foreach": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/foreach/-/foreach-2.0.5.tgz",
             "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
             "dev": true
         },
         "from": {
             "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
         },
@@ -1232,9 +1232,9 @@
             "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -1254,11 +1254,11 @@
             "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "meow": "3.7.0",
-                "normalize-package-data": "2.4.0",
-                "parse-github-repo-url": "1.4.1",
-                "through2": "2.0.3"
+                "hosted-git-info": "^2.1.4",
+                "meow": "^3.3.0",
+                "normalize-package-data": "^2.3.0",
+                "parse-github-repo-url": "^1.3.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -1273,8 +1273,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -1283,8 +1283,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stdin": {
@@ -1299,7 +1299,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -1308,11 +1308,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "map-obj": {
@@ -1327,16 +1327,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -1345,7 +1345,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -1354,7 +1354,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -1363,9 +1363,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -1380,9 +1380,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -1391,8 +1391,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "redent": {
@@ -1401,8 +1401,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "strip-bom": {
@@ -1411,7 +1411,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -1420,7 +1420,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "trim-newlines": {
@@ -1443,11 +1443,11 @@
             "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
             "dev": true,
             "requires": {
-                "dargs": "4.1.0",
-                "lodash.template": "4.4.0",
-                "meow": "4.0.1",
-                "split2": "2.2.0",
-                "through2": "2.0.3"
+                "dargs": "^4.0.1",
+                "lodash.template": "^4.0.2",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "meow": {
@@ -1456,15 +1456,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -1475,8 +1475,8 @@
             "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
             "dev": true,
             "requires": {
-                "gitconfiglocal": "1.0.0",
-                "pify": "2.3.0"
+                "gitconfiglocal": "^1.0.0",
+                "pify": "^2.3.0"
             },
             "dependencies": {
                 "pify": {
@@ -1493,8 +1493,8 @@
             "integrity": "sha512-lSgFc3zQTul31nFje2Q8XdNcTOI6B4I3mJRPCgFzHQQLfxfqdWTYzdtCaynkK5Xmb2wQlSJoKolhXJ1VhKROnQ==",
             "dev": true,
             "requires": {
-                "meow": "4.0.1",
-                "semver": "5.5.0"
+                "meow": "^4.0.0",
+                "semver": "^5.5.0"
             },
             "dependencies": {
                 "meow": {
@@ -1503,15 +1503,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -1522,34 +1522,34 @@
             "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.2"
             }
         },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "global-dirs": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/global-dirs/-/global-dirs-0.1.1.tgz",
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "graceful-fs": {
             "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
             "dev": true
         },
@@ -1559,10 +1559,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             }
         },
         "has": {
@@ -1571,7 +1571,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -1579,7 +1579,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1599,9 +1599,9 @@
             "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
-                "is-ci": "1.1.0",
-                "normalize-path": "1.0.0",
-                "strip-indent": "2.0.0"
+                "is-ci": "^1.0.10",
+                "normalize-path": "^1.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "indent-string": {
@@ -1615,8 +1615,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1632,7 +1632,7 @@
         },
         "is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
@@ -1644,11 +1644,11 @@
         },
         "is-builtin-module": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {
@@ -1663,18 +1663,18 @@
             "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
             "dev": true,
             "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
             }
         },
         "is-date-object": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-date-object/-/is-date-object-1.0.1.tgz",
             "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
             "dev": true
         },
         "is-directory": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-directory/-/is-directory-0.3.1.tgz",
             "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
             "dev": true
         },
@@ -1684,7 +1684,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-obj": {
@@ -1695,17 +1695,17 @@
         },
         "is-plain-obj": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
         "is-regex": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "1.0.3"
+                "has": "^1.0.1"
             }
         },
         "is-subset": {
@@ -1716,7 +1716,7 @@
         },
         "is-symbol": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-symbol/-/is-symbol-1.0.1.tgz",
             "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
             "dev": true
         },
@@ -1726,7 +1726,7 @@
             "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
             "dev": true,
             "requires": {
-                "text-extensions": "1.7.0"
+                "text-extensions": "^1.0.0"
             }
         },
         "is-utf8": {
@@ -1737,12 +1737,12 @@
         },
         "isarray": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
@@ -1756,8 +1756,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "json-parse-better-errors": {
@@ -1778,12 +1778,12 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
             "dev": true
         },
@@ -1799,7 +1799,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "lazy-cache": {
@@ -1815,20 +1815,20 @@
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "4.0.0",
-                "pify": "3.0.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "locate-path": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -1845,13 +1845,13 @@
         },
         "lodash.camelcase": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
             "dev": true
         },
         "lodash.kebabcase": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
             "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
             "dev": true
         },
@@ -1869,25 +1869,25 @@
         },
         "lodash.omit": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.omit/-/lodash.omit-4.5.0.tgz",
             "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
             "dev": true
         },
         "lodash.pick": {
             "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.pick/-/lodash.pick-4.4.0.tgz",
             "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
             "dev": true
         },
         "lodash.snakecase": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
             "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
             "dev": true
         },
         "lodash.startcase": {
             "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
             "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
             "dev": true
         },
@@ -1897,8 +1897,8 @@
             "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.templatesettings": "4.1.0"
+                "lodash._reinterpolate": "~3.0.0",
+                "lodash.templatesettings": "^4.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -1907,18 +1907,18 @@
             "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0"
+                "lodash._reinterpolate": "~3.0.0"
             }
         },
         "lodash.topairs": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
             "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ=",
             "dev": true
         },
         "lodash.upperfirst": {
             "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
             "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
             "dev": true
         },
@@ -1928,7 +1928,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "longest": {
@@ -1943,8 +1943,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "make-error": {
@@ -1961,7 +1961,7 @@
         },
         "map-stream": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
@@ -1977,15 +1977,15 @@
             "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
             "dev": true,
             "requires": {
-                "camelcase-keys": "4.2.0",
-                "decamelize-keys": "1.1.0",
-                "loud-rejection": "1.6.0",
-                "minimist-options": "3.0.2",
-                "normalize-package-data": "2.4.0",
-                "read-pkg-up": "3.0.0",
-                "redent": "2.0.0",
-                "trim-newlines": "2.0.0",
-                "yargs-parser": "10.1.0"
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0",
+                "yargs-parser": "^10.0.0"
             }
         },
         "mimic-fn": {
@@ -1997,9 +1997,9 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -2014,8 +2014,8 @@
             "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "is-plain-obj": "1.1.0"
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0"
             }
         },
         "mkdirp": {
@@ -2053,10 +2053,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -2071,15 +2071,15 @@
             "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "memorystream": "0.3.1",
-                "minimatch": "3.0.4",
-                "ps-tree": "1.1.0",
-                "read-pkg": "3.0.0",
-                "shell-quote": "1.6.1",
-                "string.prototype.padend": "3.0.0"
+                "ansi-styles": "^3.2.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.4",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "ps-tree": "^1.1.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2088,7 +2088,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.2"
+                        "color-convert": "^1.9.0"
                     }
                 }
             }
@@ -2116,7 +2116,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -2125,7 +2125,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optimist": {
@@ -2134,8 +2134,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -2152,12 +2152,12 @@
             "integrity": "sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-spinners": "1.3.1",
-                "log-symbols": "2.2.0",
-                "strip-ansi": "4.0.0",
-                "wcwidth": "1.0.1"
+                "chalk": "^2.3.1",
+                "cli-cursor": "^2.1.0",
+                "cli-spinners": "^1.1.0",
+                "log-symbols": "^2.2.0",
+                "strip-ansi": "^4.0.0",
+                "wcwidth": "^1.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2172,7 +2172,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -2189,21 +2189,21 @@
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-try": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
@@ -2219,8 +2219,8 @@
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.2",
-                "json-parse-better-errors": "1.0.2"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "path-exists": {
@@ -2251,16 +2251,16 @@
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pify": {
@@ -2281,7 +2281,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "process-nextick-args": {
@@ -2292,11 +2292,11 @@
         },
         "ps-tree": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/ps-tree/-/ps-tree-1.1.0.tgz",
             "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4"
+                "event-stream": "~3.3.0"
             }
         },
         "q": {
@@ -2307,7 +2307,7 @@
         },
         "quick-lru": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/quick-lru/-/quick-lru-1.1.0.tgz",
             "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
             "dev": true
         },
@@ -2317,9 +2317,9 @@
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "4.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "3.0.0"
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
@@ -2328,8 +2328,8 @@
             "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "3.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
             }
         },
         "readable-stream": {
@@ -2338,13 +2338,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -2361,8 +2361,8 @@
             "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
             "dev": true,
             "requires": {
-                "indent-string": "3.2.0",
-                "strip-indent": "2.0.0"
+                "indent-string": "^3.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "regenerator-runtime": {
@@ -2383,7 +2383,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "require-from-string": {
@@ -2394,17 +2394,17 @@
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             },
             "dependencies": {
                 "resolve-from": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/resolve-from/-/resolve-from-1.0.1.tgz",
                     "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
                     "dev": true
                 }
@@ -2415,7 +2415,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-from": {
@@ -2426,11 +2426,11 @@
         },
         "resolve-global": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/resolve-global/-/resolve-global-0.1.0.tgz",
             "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
             "dev": true,
             "requires": {
-                "global-dirs": "0.1.1"
+                "global-dirs": "^0.1.0"
             }
         },
         "restore-cursor": {
@@ -2439,8 +2439,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "right-align": {
@@ -2450,7 +2450,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -2459,7 +2459,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -2475,29 +2475,29 @@
         },
         "shebang-command": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
         "shell-quote": {
             "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/shell-quote/-/shell-quote-1.6.1.tgz",
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "dev": true,
             "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
             }
         },
         "signal-exit": {
@@ -2512,7 +2512,7 @@
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "dev": true,
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
         },
         "source-map-support": {
@@ -2521,8 +2521,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.0",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -2539,8 +2539,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -2555,8 +2555,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -2571,7 +2571,7 @@
             "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split2": {
@@ -2580,7 +2580,7 @@
             "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.2"
             }
         },
         "sprintf-js": {
@@ -2590,22 +2590,22 @@
         },
         "stream-combiner": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "string.prototype.padend": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
             "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.4.3",
+                "function-bind": "^1.0.2"
             }
         },
         "string_decoder": {
@@ -2614,7 +2614,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -2622,7 +2622,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -2648,8 +2648,8 @@
             "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2",
-                "uuid": "2.0.3"
+                "os-tmpdir": "^1.0.0",
+                "uuid": "^2.0.1"
             }
         },
         "text-extensions": {
@@ -2660,7 +2660,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -2670,8 +2670,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "trim-newlines": {
@@ -2692,14 +2692,14 @@
             "integrity": "sha512-klJsfswHP0FuOLsvBZ/zzCfUvakOSSxds78mVeK7I+qP76YWtxf16hEZsp3U+b0kIo82R5UatGFeblYMqabb2Q==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "buffer-from": "1.1.0",
-                "diff": "3.5.0",
-                "make-error": "1.3.4",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.6",
-                "yn": "2.0.0"
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
             }
         },
         "tslib": {
@@ -2712,18 +2712,18 @@
             "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.16.0",
-                "diff": "3.5.0",
-                "glob": "7.1.2",
-                "js-yaml": "3.12.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.8.1",
-                "semver": "5.5.0",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.27.2"
             }
         },
         "tslint-eslint-rules": {
@@ -2746,7 +2746,7 @@
                     "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
                     "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
                     "requires": {
-                        "tslib": "1.9.0"
+                        "tslib": "^1.7.1"
                     }
                 }
             }
@@ -2756,7 +2756,7 @@
             "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.1.0.tgz",
             "integrity": "sha512-p7xN6cN6y2REFT/11Xl4OAPdhPLHcsZk2IfA8rFS9wi3hhkY6Shz+yoJ61Z+GJ8L4TsRhIbG/09w3e1sdOHs9g==",
             "requires": {
-                "tsutils": "2.29.0"
+                "tsutils": "^2.12.1"
             }
         },
         "tsutils": {
@@ -2764,7 +2764,7 @@
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
             }
         },
         "typescript": {
@@ -2780,9 +2780,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -2825,8 +2825,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "wcwidth": {
@@ -2835,7 +2835,7 @@
             "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
             "dev": true,
             "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
             }
         },
         "which": {
@@ -2844,7 +2844,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "window-size": {
@@ -2878,9 +2878,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             },
             "dependencies": {
@@ -2899,7 +2899,7 @@
             "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             }
         },
         "yn": {

--- a/src/configs/tslint-override.ts
+++ b/src/configs/tslint-override.ts
@@ -5,6 +5,7 @@ export default {
 
         // TypeScript-specific
         "member-access": [true, "no-public"],
+        "promise-function-async": false,
 
         // Style
         "array-type": [
@@ -31,6 +32,11 @@ export default {
                 "check-type-operator",
                 "check-preblock"
         ],
+        "no-unnecessary-type-assertion": true,
+        "match-default-export-name": true,
+        "no-boolean-literal-compare": true,
+        "no-unnecessary-qualifier": true,
+        "return-undefined": false,
 
         // Functionality
         "await-promise": [
@@ -66,6 +72,15 @@ export default {
             }
         ],
         "prefer-object-spread": true,
+        "no-unsafe-any": false,
+        "no-floating-promises": false,
+        "no-inferred-empty-object-type": true,
+        "no-use-before-declare": true,
+        "no-void-expression": [true, "ignore-arrow-function-shorthand"],
+        "restrict-plus-operands": true,
+        "strict-boolean-expressions": false,
+        "strict-type-predicates": true,
+        "use-default-type-parameter": true,
 
         // Maintainability
         "cyclomatic-complexity": true,
@@ -90,6 +105,8 @@ export default {
         "no-parameter-reassignment": true,
         "deprecation": true,
         "indent": [true, "spaces", 4],
-        "no-duplicate-imports": true
+        "no-duplicate-imports": true,
+        "prefer-readonly": true,
+        "completed-docs": false
     }
 };


### PR DESCRIPTION
Данный реквест порожден различиями работы штатного tslint'а в webstorm'е и его же, но через CLI(с указанием опции --project).
Различия обусловлены https://palantir.github.io/tslint/usage/type-checking/. 
На текущий момент из коробки webstorm это не поддерживает(https://youtrack.jetbrains.com/issue/WEB-22778#), вследствии чего при попытке использовать tslint в webstorm и CLI (с указанием опции --project) получаются разные результаты в части правил с "requires type check". 
Данный реквест прорабатывает данный набор правил, но не гарантирует их работу в webstorm'е (требуется установка и доп. настройка https://github.com/angelozerr/tslint-language-service в самом проекте)