### PR TITLE
fix: Remove deprecated rules and some unuseful restrictions

### DIFF
--- a/src/configs/rxjs-override.ts
+++ b/src/configs/rxjs-override.ts
@@ -1,7 +1,5 @@
 export const rxjsOverrideConfig = {
     rules: {
-        'rxjs-no-add': { severity: 'error' },
-        'rxjs-no-patched': { severity: 'error' },
         'rxjs-no-internal': { severity: 'error' }
     }
 };

--- a/src/configs/rxjs-override.ts
+++ b/src/configs/rxjs-override.ts
@@ -2,8 +2,6 @@ export const rxjsOverrideConfig = {
     rules: {
         'rxjs-no-add': { severity: 'error' },
         'rxjs-no-patched': { severity: 'error' },
-        'rxjs-no-wholesale': { severity: 'error' },
-        'rxjs-no-finnish': { severity: 'error' },
         'rxjs-no-internal': { severity: 'error' }
     }
 };


### PR DESCRIPTION
Убраны некоторые по разным причинам неактуальные для RxJS настройки.

See also: https://blog.angularindepth.com/rxjs-tslint-rules-for-version-6-d10e2482292d