### PR TITLE
fix(config): fixed overlap rules for private properties

### DIFF
--- a/src/configs/custom-rules.ts
+++ b/src/configs/custom-rules.ts
@@ -23,6 +23,7 @@ export const customRules = {
             { type: 'enumMember', format: ['UPPER_CASE', 'PascalCase'] },
 
             { type: 'property', format: ['strictCamelCase', 'UPPER_CASE'] },
+            { type: 'property', modifiers: 'private', leadingUnderscore: 'allow' },
 
             { type: 'class', modifiers: 'abstract', prefix: 'Abstract' },
             { type: 'class', format: 'StrictPascalCase' },

--- a/test/rules/orthodox-getter-and-setter/default/test.ts.lint
+++ b/test/rules/orthodox-getter-and-setter/default/test.ts.lint
@@ -98,3 +98,18 @@ class Test9 {
     }
 ~~~~~ [Getters must be declared before setters.]
 }
+
+class Test10 {
+    private _otherProperty: any;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Private property with leading underscore must be used only for getter or setter.]
+
+    get property() {
+        return this._property;
+    }
+
+    set property(value) {
+        this._property = value;
+    }
+
+    private _property: string;
+}


### PR DESCRIPTION
Разрешение конфликта правил `naming-convention` и `orthodox-getter-and-setter`