### PR TITLE
Disable newline-per-chained-call rule

### DIFF
--- a/src/configs/tslint-override.ts
+++ b/src/configs/tslint-override.ts
@@ -40,6 +40,7 @@ export const tslintOverride = {
         "return-undefined": false,
         "class-name": false,
         "interface-name": false,
+        "newline-per-chained-call": false,
 
         // Functionality
         "await-promise": [


### PR DESCRIPTION
Во многих местах подсвечиваются короткие и понятные цепочки, например:

![image](https://user-images.githubusercontent.com/363471/90865466-0dd94400-e39b-11ea-966f-5075cd3d916f.png)

В tslint это правило нельзя настроить как в eslint, задав ignoreChainWithDepth (оно по умолчанию кстати 2).
Поэтому предлагаю это правило совсем отключить, до перехода на eslint.